### PR TITLE
Updates README with instructions for Makefile to preview rendered Markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+preview:
+	docker run -p "9000:9000" -p "35729:35729" \
+	-v $(CURDIR)/labs:/opt/labs \
+	containers.cisco.com/asroach/learning-labs-previewer:latest
+	open http://localhost:9000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-preview:
-	docker run -p "9000:9000" -p "35729:35729" \
-	-v $(CURDIR)/labs:/opt/labs \
-	containers.cisco.com/asroach/learning-labs-previewer:latest
-	open http://localhost:9000

--- a/{{cookiecutter.module_name}}/README.md
+++ b/{{cookiecutter.module_name}}/README.md
@@ -22,7 +22,7 @@ For your repository, answer these questions:
 
 You can preview how the Markdown renders by using a pre-built Docker image. The `Makefile` in the root of the repository lets you run `make preview` to view the output HTML.
 
-1. Make sure you have Docker installed locally. If not, install Docker for your operating system.
+1. Make sure you have Docker installed locally. If not, [install Docker](https://docs.docker.com/install/) for your operating system.
 ```
 $ docker -v
 ```

--- a/{{cookiecutter.module_name}}/README.md
+++ b/{{cookiecutter.module_name}}/README.md
@@ -18,6 +18,22 @@ For your repository, answer these questions:
 * How do I get started?
 * Where can I get more help?
 
+## Preview Learning Lab Markdown locally
+
+You can preview how the Markdown renders by using a pre-built Docker image. The `Makefile` in the root of the repository lets you run `make preview` to view the output HTML.
+
+1. Make sure you have Docker installed locally. If not, install Docker for your operating system.
+```
+$ docker -v
+```
+1. In the root of the repository, run:
+```
+$ make preview
+```
+1. Open a browser window with the URL: `http://localhost:9000`.
+1. Click a folder to find the Markdown file you want to preview.
+1. When you are done previewing, type `Ctrl+C` to stop running the Docker container.
+
 ## Contributing
 
 These learning modules are for public consumption, so you must ensure that you have the rights to any content that you contribute.
@@ -38,11 +54,11 @@ A DevNet reviewer then creates a release on the repository with the latest `mast
 #### Editors
 
 You can write Markdown in a plain text editor, and desktop and Web-based options allow you to write and preview your work at the same time. We recommend Visual Studio Code [Download](https://code.visualstudio.com/) for these reasons:
-- Lightweight environment for coding (or writing Markdown)
-- Available on Mac OS, Linux or Windows
-- Github Client integration
-- Great Markdown preview features native in the editor
-- Intuitive operation and structure
+- Lightweight environment for coding (or writing Markdown).
+- Available on Mac OS, Linux or Windows.
+- Github Client integration.
+- Great Markdown preview features native in the editor.
+- Intuitive operation and structure.
 
 You can validate a JSON file by using the [online formatter and validator](https://jsonformatter.curiousconcept.com).
 


### PR DESCRIPTION
Requires Docker to be installed locally, super handy. I'll also update the README to make sure there are instructions for how to preview.